### PR TITLE
Add support for later versions of PHP

### DIFF
--- a/src/csrfhandler/csrf.php
+++ b/src/csrfhandler/csrf.php
@@ -28,7 +28,14 @@
 			
 			$clientIp = self::getRealIpAddr();
 			
-			$hashedToken = base64_encode(password_hash(base64_encode($keySet.$userAgent.$clientIp), PASSWORD_BCRYPT));
+			if (phpversion() < 5.5)
+			{
+				$hashedToken = hash('sha256', base64_encode($keySet.$userAgent.$clientIp));
+			}
+			else
+			{
+				$hashedToken = base64_encode(password_hash(base64_encode($keySet.$userAgent.$clientIp), PASSWORD_BCRYPT));
+			}
 			
 			self::setToken($hashedToken);
 			


### PR DESCRIPTION
Since password_hash doesn't exist in PHP below 5.5, fallback to sha256 hash algo.

See:
https://secure.php.net/password_hash