### PR TITLE
Fix bug that would cause first token to not be inserted into session

### DIFF
--- a/src/csrfhandler/csrf.php
+++ b/src/csrfhandler/csrf.php
@@ -58,6 +58,10 @@
 			self::startSession();
 			
 			$tokenList = unserialize($_SESSION['X-CSRF-TOKEN-LIST']);
+			if (!is_array($tokenList))
+			{
+				$tokenList = array();
+			}			
 			array_push($tokenList, $token);
 			$_SESSION['X-CSRF-TOKEN-LIST'] = serialize($tokenList);
 		}


### PR DESCRIPTION
Fixed a bug that, if the $_SESSION['X-CSRF-TOKEN-LIST'] variable was empty, it was not able to push the first token into the list.